### PR TITLE
Fix: DecodedPika extends DeconstructedSnowflake

### DIFF
--- a/impl/js/src/pika.ts
+++ b/impl/js/src/pika.ts
@@ -1,7 +1,7 @@
 import {randomBytes} from 'crypto';
 import {networkInterfaces} from 'os';
 import {error, warn} from './logger';
-import {EpochResolvable, Snowflake} from './snowflake';
+import {DeconstructedSnowflake, EpochResolvable, Snowflake} from './snowflake';
 
 export interface PikaPrefixDefinition<P extends string> {
 	prefix: P;
@@ -10,7 +10,7 @@ export interface PikaPrefixDefinition<P extends string> {
 	metadata?: Record<string, unknown>;
 }
 
-export interface DecodedPika<P extends string> {
+export interface DecodedPika<P extends string> extends Omit<DeconstructedSnowflake, 'id'> {
 	prefix: P;
 
 	/**


### PR DESCRIPTION
This change extends `DeconstructedSnowflake` to `DecodedPika` omitting it's `id` field since that's not destructed to the decode response.