### PR TITLE
Implement Debug trait (+ Default trait on InitOptions)

### DIFF
--- a/impl/rs/src/pika.rs
+++ b/impl/rs/src/pika.rs
@@ -24,7 +24,7 @@ pub struct DecodedPika {
     pub prefix_record: PrefixRecord,
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Pika {
     pub prefixes: Vec<PrefixRecord>,
     pub epoch: u64,

--- a/impl/rs/src/pika.rs
+++ b/impl/rs/src/pika.rs
@@ -39,6 +39,16 @@ pub struct InitOptions {
     pub disable_lowercase: Option<bool>,
 }
 
+impl Default for InitOptions {
+    fn default() -> Self {
+        InitOptions {
+            epoch: None,
+            node_id: None,
+            disable_lowercase: None,
+        }
+    }
+}
+
 pub const DEFAULT_EPOCH: u64 = 1_640_995_200_000;
 
 impl Pika {


### PR DESCRIPTION
Threw in the default trait since it makes initializing Pika much nicer when you only care about a single option:

```rust
Pika::new(
    prefixes,
    &InitOptions {
        disable_lowercase: Some(true),
        ..InitOptions::default()
    },
)
```