### PR TITLE
Fixed validation bug (JS implementation)

### DIFF
--- a/impl/js/src/pika.ts
+++ b/impl/js/src/pika.ts
@@ -124,7 +124,9 @@ export class Pika<Prefixes extends string> {
 			return false;
 		}
 
-		const [prefix, tail = null] = maybeId.split('_', 2);
+		const s = maybeId.split('_');
+		const tail = s[s.length - 1];
+		const prefix = s.slice(0, s.length - 1).join('_');
 
 		if (!tail) {
 			return false;


### PR DESCRIPTION
## Problem
The validation in the JS library doesn't account for id's containing `_` e.g. `sk_test_xxxx` will parse the `sk` as the prefix and `test_xxxxx` as the tail.

## Solution
Use the same logic to split the keys found in the decode function.

