### PR TITLE
Rust Pika Implementation Improvements

### DIFF
--- a/impl/rs/Cargo.lock
+++ b/impl/rs/Cargo.lock
@@ -3,25 +3,10 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "base64"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bitflags"
@@ -69,12 +54,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memchr"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,12 +77,10 @@ dependencies = [
 
 [[package]]
 name = "pika"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
- "base64",
  "mac_address",
  "rand",
- "regex",
 ]
 
 [[package]]
@@ -141,23 +118,6 @@ checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
 ]
-
-[[package]]
-name = "regex"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "wasi"

--- a/impl/rs/Cargo.toml
+++ b/impl/rs/Cargo.toml
@@ -7,7 +7,5 @@ description="Pika ID implementation in Rust"
 license = "MPL-2.0"
 
 [dependencies]
-base64 = "0.13.0"
 mac_address = "1.1.3"
-regex = "1.6.0"
 rand = "0.8.5"

--- a/impl/rs/src/base64.rs
+++ b/impl/rs/src/base64.rs
@@ -1,0 +1,70 @@
+const BASE64_CHARS: [u8; 64] = [
+    b'A', b'B', b'C', b'D', b'E', b'F', b'G', b'H', b'I', b'J', b'K', b'L', b'M', b'N', b'O', b'P',
+    b'Q', b'R', b'S', b'T', b'U', b'V', b'W', b'X', b'Y', b'Z', b'a', b'b', b'c', b'd', b'e', b'f',
+    b'g', b'h', b'i', b'j', b'k', b'l', b'm', b'n', b'o', b'p', b'q', b'r', b's', b't', b'u', b'v',
+    b'w', b'x', b'y', b'z', b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9', b'+', b'/'
+];
+
+// Base64 encode a slice of bytes
+pub fn base64_encode(input: String) -> String {
+    let mut result = String::new();
+    let mut buffer: u32 = 0;
+    let mut bits_left = 0;
+
+    for byte in input.into_bytes() {
+        buffer = (buffer << 8) | byte as u32;
+        bits_left += 8;
+
+        while bits_left >= 6 {
+            bits_left -= 6;
+            let index = ((buffer >> bits_left) & 0b111111) as usize;
+            result.push(BASE64_CHARS[index] as char);
+        }
+    }
+
+    if bits_left > 0 {
+        buffer <<= 6 - bits_left;
+        let index = (buffer & 0b111111) as usize;
+        result.push(BASE64_CHARS[index] as char);
+    }
+
+    while result.len() % 4 != 0 {
+        result.push('=');
+    }
+
+    result
+}
+
+// Base64 decode a string into a vector of bytes
+pub fn base64_decode(encoded: &str) -> Option<Vec<u8>> {
+    let mut decoded = Vec::new();
+    let mut padding = 0;
+    let mut buffer = 0;
+    let mut bits = 0;
+
+    for c in encoded.chars() {
+        let value = match BASE64_CHARS.iter().position(|&x| x == c as u8) {
+            Some(v) => v as u32,
+            None if c == '=' => {
+                padding += 1;
+                continue;
+            }
+            None => return None,
+        };
+
+        buffer = (buffer << 6) | value;
+        bits += 6;
+
+        if bits >= 8 {
+            bits -= 8;
+            decoded.push((buffer >> bits) as u8);
+            buffer &= (1 << bits) - 1;
+        }
+    }
+
+    if bits >= 6 || padding > 2 || (padding > 0 && bits > 0) {
+        return None;
+    }
+
+    Some(decoded)
+}

--- a/impl/rs/src/lib.rs
+++ b/impl/rs/src/lib.rs
@@ -8,4 +8,5 @@
 
 pub mod pika;
 pub mod snowflake;
+mod base64;
 mod utils;

--- a/impl/rs/src/pika.rs
+++ b/impl/rs/src/pika.rs
@@ -109,7 +109,7 @@ impl Pika {
     }
 
     pub fn gen(&mut self, prefix: &str) -> Result<String, Error> {
-        let valid_prefix = prefix.chars().all(|c| c.is_ascii_alphanumeric()) && prefix.len() <= 32;
+        let valid_prefix = prefix.chars().all(|c| c.is_ascii_alphanumeric()) && prefix.len() <= 32 && prefix.len() >= 1;
 
         assert!(valid_prefix, "Invalid prefix: {}", prefix);
 

--- a/impl/rs/src/pika.rs
+++ b/impl/rs/src/pika.rs
@@ -52,15 +52,8 @@ pub const DEFAULT_EPOCH: u64 = 1_640_995_200_000;
 
 impl Pika {
     pub fn new(prefixes: Vec<PrefixRecord>, options: &InitOptions) -> Pika {
-        let epoch = match options.epoch {
-            Some(epoch) => epoch,
-            None => DEFAULT_EPOCH,
-        };
-
-        let node_id = match options.node_id {
-            Some(node_id) => node_id,
-            None => Self::compute_node_id(),
-        };
+        let epoch = options.epoch.unwrap_or(DEFAULT_EPOCH);
+        let node_id = options.node_id.unwrap_or(Self::compute_node_id());
 
         Pika {
             prefixes,

--- a/impl/rs/src/pika.rs
+++ b/impl/rs/src/pika.rs
@@ -1,7 +1,6 @@
 use std::io::Error;
 
-use regex::Regex;
-
+use crate::base64::*;
 use crate::snowflake::{self, Snowflake};
 
 #[derive(Clone, Debug)]
@@ -89,7 +88,7 @@ impl Pika {
         let tail = s[1].to_string();
 
         let prefix_record = self.prefixes.iter().find(|x| x.prefix == prefix);
-        let decoded_tail = base64::decode(&tail).unwrap();
+        let decoded_tail = base64_decode(&tail).unwrap();
 
         let snowflake = self
             .snowflake
@@ -110,9 +109,9 @@ impl Pika {
     }
 
     pub fn gen(&mut self, prefix: &str) -> Result<String, Error> {
-        let valid_prefix: Regex = Regex::new(r"^[a-zA-Z0-9]{1,32}$").unwrap();
+        let valid_prefix = prefix.chars().all(|c| c.is_ascii_alphanumeric()) && prefix.len() <= 32;
 
-        assert!(valid_prefix.is_match(prefix), "Invalid prefix: {}", prefix);
+        assert!(valid_prefix, "Invalid prefix: {}", prefix);
 
         let prefix_record = self.prefixes.iter().find(|x| x.prefix == prefix);
 
@@ -126,10 +125,10 @@ impl Pika {
             format!(
                 "{}_s_{}",
                 prefix,
-                base64::encode(random_bytes + &snowflake).replace('=', "")
+                base64_encode(random_bytes + &snowflake).replace('=', "")
             )
         } else {
-            format!("{}_{}", prefix, base64::encode(snowflake).replace('=', ""))
+            format!("{}_{}", prefix, base64_encode(snowflake).replace('=', ""))
         };
 
         Ok(id)


### PR DESCRIPTION
hiiiiiii,

so i've done some small improvements/optimizations to the pika rs implementation.

firstly, I've gotten rid of using the base64 crate, and instead replacing it with my own optimized base64 encode and decode implementation.

then, i've gotten rid of the regex crate, and instead replaced it with built-in rust functions, since the regex doesn't really need to be there due to the easiness of checking the validity.
```rs
let valid_prefix = prefix.chars().all(|c| c.is_ascii_alphanumeric()) && prefix.len() <= 32 && prefix.len() >= 1;
``` 
is the implementation I did instead of a regex.

thought about reimplementing the mac_address and rand stuff that we need for pika, if y'all want that I can work on it to make it cross platform, to bring down the external dependencies to I think 1 (winapi)

builds correctly, passes all the tests we have.

cheers!